### PR TITLE
NODE-288: Got rid of iregex with alternatives to support building on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ clean: down $(shell find . -type f -name "Cargo.toml" | awk '{print $$1"/clean"}
 # Defining rules so each target building a contract only depends on its own source. Needs GNU Make.
 # Building either a call or a define, leaving the WASM files in <contract>/target/wasm32-unknown-unknown/release/
 define CONTRACT_rule
-.make/contracts/$(1): $$(shell find $(1) -type f -iregex ".*/Cargo\.toml\|.*/src/.*\.rs") .make/rustup-update
+.make/contracts/$(1): $$(shell find $(1) -type f \( -name "Cargo.toml" -o -wholename "*/src/*.rs" \)) .make/rustup-update
 	cd $(1) && cargo +nightly build --release --target wasm32-unknown-unknown
 	mkdir -p $$(dir $$@) && touch $$@
 endef

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ You can use `make up` to start a single local node in Docker using the `docker-c
 
 To deploy the contracts you have to use the `casperlabs-client`, which can talk to a CasperLabs Node. Packages are published to http://repo.casperlabs.io/casperlabs/repo
 
-For example you an install the client on Ubuntu as follows:
+For example you an install the client on Ubuntu as follows (please substitute `[VERSION]` with the what you can find in the repo):
 
 ```console
-curl -o casperlabs-client.deb http://repo.casperlabs.io/casperlabs/repo/dev/casperlabs-client_0.0_all.deb
+curl -o casperlabs-client.deb http://repo.casperlabs.io/casperlabs/repo/dev/casperlabs-client_[VERSION]_all.deb
 sudo dpkg -i ./casperlabs-client.deb
 ```
 
@@ -31,9 +31,9 @@ Depending on your version of Ubuntu you may see errors about unmet dependencies 
 You can also install from tarball:
 
 ```console
-curl -O http://repo.casperlabs.io/casperlabs/repo/dev/casperlabs-client-0.0.tgz
-tar -xzf casperlabs-client-0.0.tgz
-alias casperlabs-client=$PWD/casperlabs-client-0.0/bin/casperlabs-client
+curl -O http://repo.casperlabs.io/casperlabs/repo/dev/casperlabs-client-[VERSION].tgz
+tar -xzf casperlabs-client-[VERSION].tgz
+alias casperlabs-client=$PWD/casperlabs-client-[VERSION]/bin/casperlabs-client
 casperlabs-client --version
 ```
 


### PR DESCRIPTION
MacOS doesn't support the `find -iregex "(pat1\|pat2)"` pattern.