### PR TITLE
EE-228: Bump FFI crate version number for compatibility with current execution engine

### DIFF
--- a/counter/call/Cargo.toml
+++ b/counter/call/Cargo.toml
@@ -8,4 +8,4 @@ name = "countercall"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", version = "0.2.0" }
+common = { package = "casperlabs-contract-ffi", version = "0.3.0" }

--- a/counter/define/Cargo.toml
+++ b/counter/define/Cargo.toml
@@ -8,4 +8,4 @@ name = "counterdefine"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", version = "0.2.0" }
+common = { package = "casperlabs-contract-ffi", version = "0.3.0" }

--- a/hello-name/call/Cargo.toml
+++ b/hello-name/call/Cargo.toml
@@ -8,4 +8,4 @@ name = "helloworld"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", version = "0.2.0" }
+common = { package = "casperlabs-contract-ffi", version = "0.3.0" }

--- a/hello-name/define/Cargo.toml
+++ b/hello-name/define/Cargo.toml
@@ -8,4 +8,4 @@ name = "helloname"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", version = "0.2.0" }
+common = { package = "casperlabs-contract-ffi", version = "0.3.0" }

--- a/mailing-list/call/Cargo.toml
+++ b/mailing-list/call/Cargo.toml
@@ -8,5 +8,5 @@ name = "mailinglistcall"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", version = "0.2.0" }
+common = { package = "casperlabs-contract-ffi", version = "0.3.0" }
 

--- a/mailing-list/define/Cargo.toml
+++ b/mailing-list/define/Cargo.toml
@@ -8,5 +8,5 @@ name = "mailinglistdefine"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", version = "0.2.0" }
+common = { package = "casperlabs-contract-ffi", version = "0.3.0" }
 


### PR DESCRIPTION
Relates to
https://casperlabs.atlassian.net/browse/EE-228
https://casperlabs.atlassian.net/browse/NODE-367