### PR TITLE
NO-TICKET: Update Makefile so fetches rust-toolchain ver only.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ EXAMPLES := $(shell find . -type f -name Cargo.toml | awk -F / '{print $$2}' | u
 # Find all contracts, e.g. "hello-name/call" and "hello-name/define"
 CONTRACTS := $(shell find . -type f -name Cargo.toml | sed 's/\/Cargo.toml//' | sed 's/.\///')
 
+RUST_TOOLCHAIN := $(shell cat rust-toolchain)
+
 all: $(EXAMPLES)
 
 clean: down $(shell find . -type f -name "Cargo.toml" | awk '{print $$1"/clean"}')
@@ -35,9 +37,9 @@ $(foreach d,$(CONTRACTS),$(eval $(call CONTRACT_rule,$(d))))
 
 
 .make/rustup-update:
-	rustup update
-	rustup toolchain install nightly
-	rustup target add --toolchain nightly wasm32-unknown-unknown
+	rustup update $(RUST_TOOLCHAIN)
+	rustup toolchain install $(RUST_TOOLCHAIN)
+	rustup target add --toolchain $(RUST_TOOLCHAIN) wasm32-unknown-unknown
 	mkdir -p $(dir $@) && touch $@
 
 

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,6 @@ EXAMPLES := $(shell find . -type f -name Cargo.toml | awk -F / '{print $$2}' | u
 # Find all contracts, e.g. "hello-name/call" and "hello-name/define"
 CONTRACTS := $(shell find . -type f -name Cargo.toml | sed 's/\/Cargo.toml//' | sed 's/.\///')
 
-RUST_TOOLCHAIN := $(shell cat rust-toolchain)
-
 all: $(EXAMPLES)
 
 clean: down $(shell find . -type f -name "Cargo.toml" | awk '{print $$1"/clean"}')
@@ -36,7 +34,8 @@ $(foreach d,$(CONTRACTS),$(eval $(call CONTRACT_rule,$(d))))
 	cd $* && cargo clean
 
 
-.make/rustup-update:
+.make/rustup-update: rust-toolchain
+	$(eval RUST_TOOLCHAIN = $(shell cat rust-toolchain))
 	rustup update $(RUST_TOOLCHAIN)
 	rustup toolchain install $(RUST_TOOLCHAIN)
 	rustup target add --toolchain $(RUST_TOOLCHAIN) wasm32-unknown-unknown


### PR DESCRIPTION
If `nightly` misses some of the components like `rls`, `clippy` etc (which happens very often) `rustup-update` fails. Instead of trying to update every rust version there is just update (and use) one from the `rust-toolchain` file.