### PR TITLE
EE-276: Fix nonces

### DIFF
--- a/combined-contracts/call/Cargo.toml
+++ b/combined-contracts/call/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "test_combined_contracts_call"
+version = "0.1.0"
+authors = ["Srinivas Reddy Thatiparthy <thatiparthysreenivas@gmail.com>"]
+edition = "2018"
+
+[dependencies]

--- a/combined-contracts/call/src/lib.rs
+++ b/combined-contracts/call/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/combined-contracts/define/Cargo.toml
+++ b/combined-contracts/define/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "combined-contracts-define"
+version = "0.1.0"
+authors = ["Srinivas Reddy Thatiparthy <srini@casperlabs.io>"]
+edition = "2018"
+
+[lib]
+name = "test_combinedcontractsdefine"
+crate-type = ["cdylib"]
+
+[dependencies]
+common = { package = "casperlabs-contract-ffi", version = "0.5.0" }

--- a/combined-contracts/define/src/lib.rs
+++ b/combined-contracts/define/src/lib.rs
@@ -1,0 +1,128 @@
+#![no_std]
+#![feature(alloc)]
+#[macro_use]
+
+extern crate alloc;
+extern crate common;
+
+use alloc::collections::BTreeMap;
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use common::contract_api::*;
+use common::contract_api::pointers::UPointer;
+use common::key::Key;
+
+fn hello_name(name: &str) -> String {
+    let mut result = String::from("Hello, ");
+    result.push_str(name);
+    result
+}
+
+#[no_mangle]
+pub extern "C" fn hello_name_ext() {
+    let name: String = get_arg(0);
+    let y = hello_name(&name);
+    ret(&y, &Vec::new());
+}
+
+
+fn get_list_key(name: &str) -> UPointer<Vec<String>> {
+    get_uref(name).to_u_ptr().unwrap()
+}
+
+fn update_list(name: String) {
+    let list_key = get_list_key("list");
+    let mut list = read(list_key.clone());
+    list.push(name);
+    write(list_key, list);
+}
+
+fn sub(name: String) -> Option<UPointer<Vec<String>>> {
+    if has_uref(&name) {
+        None //already subscribed
+    } else {
+        let init_message = vec![String::from("Welcome!")];
+        let new_key = new_uref(init_message);
+        add_uref(&name, &new_key.clone().into());
+        update_list(name);
+        Some(new_key)
+    }
+}
+
+fn publish(msg: String) {
+    let curr_list = read(get_list_key("list"));
+    for name in curr_list.iter() {
+        let uref = get_list_key(name);
+        let mut messages = read(uref.clone());
+        messages.push(msg.clone());
+        write(uref, messages);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn mailing_list_ext() {
+    let method_name: String = get_arg(0);
+    match method_name.as_str() {
+        "sub" => match sub(get_arg(1)).map(Key::from) {
+            Some(key) => {
+                let extra_urefs = vec![key];
+                ret(&Some(key), &extra_urefs);
+            }
+            none => ret(&none, &Vec::new()),
+        },
+        //Note that this is totally insecure. In reality
+        //the pub method would be only available under an
+        //unforgable reference because otherwise anyone could
+        //spam the mailing list.
+        "pub" => {
+            publish(get_arg(1));
+        }
+        _ => panic!("Unknown method name!"),
+    }
+}
+
+
+#[no_mangle]
+pub extern "C" fn counter_ext() {
+    let i_key: UPointer<i32> = get_uref("count").to_u_ptr().unwrap();
+    let method_name: String = get_arg(0);
+    match method_name.as_str() {
+        "inc" => add(i_key, 1),
+        "get" => {
+            let result = read(i_key);
+            ret(&result, &Vec::new());
+        }
+        _ => panic!("Unknown method name!"),
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn call() {
+
+    let _hello_name_hash = store_function("hello_name_ext", BTreeMap::new());
+    add_uref("hello", &_hello_name_hash.into());
+
+    let counter_local_key = new_uref(0); //initialize counter
+
+    //create map of references for stored contract
+    let mut counter_urefs: BTreeMap<String, Key> = BTreeMap::new();
+    let key_name = String::from("count");
+    counter_urefs.insert(key_name, counter_local_key.into());
+
+    let _counter_hash = store_function("counter_ext", counter_urefs);
+    add_uref("counter", &_counter_hash.into());
+
+
+    let init_list: Vec<String> = Vec::new();
+    let list_key = new_uref(init_list);
+
+    //create map of references for stored contract
+    let mut mailing_list_urefs: BTreeMap<String, Key> = BTreeMap::new();
+    let key_name = String::from("list");
+    mailing_list_urefs.insert(key_name, list_key.into());
+
+    let _mailing_list_hash = store_function("mailing_list_ext", mailing_list_urefs);
+
+    add_uref("mailing", &_mailing_list_hash.into());
+}

--- a/counter/call/src/lib.rs
+++ b/counter/call/src/lib.rs
@@ -12,10 +12,10 @@ use common::contract_api::pointers::ContractPointer;
 
 #[no_mangle]
 pub extern "C" fn call() {
-    //This hash comes from blake2b256( [0;32] ++ [0;8] ++ [0;4] )
+    // This hash comes from a hash of address=[48; 32]; nonce=3; fn_store_id=0
     let hash = ContractPointer::Hash([
-        164, 102, 153, 51, 236, 214, 169, 167, 126, 44, 250, 247, 179, 214, 203, 229, 239, 69, 145,
-        25, 5, 153, 113, 55, 255, 188, 176, 201, 7, 4, 42, 100,
+        141, 28, 213, 149, 230, 231, 61, 223, 143, 211, 37, 248, 146, 126, 101, 96, 197, 73, 164,
+        185, 147, 226, 1, 127, 25, 96, 126, 228, 231, 147, 193, 252,
     ]);
     let arg = "inc";
     let _result: () = call_contract(hash.clone(), &arg, &Vec::new());

--- a/counter/call/src/lib.rs
+++ b/counter/call/src/lib.rs
@@ -14,8 +14,8 @@ use common::contract_api::pointers::ContractPointer;
 pub extern "C" fn call() {
     // This hash comes from a hash of address=[48; 32]; nonce=3; fn_store_id=0
     let hash = ContractPointer::Hash([
-        141, 28, 213, 149, 230, 231, 61, 223, 143, 211, 37, 248, 146, 126, 101, 96, 197, 73, 164,
-        185, 147, 226, 1, 127, 25, 96, 126, 228, 231, 147, 193, 252,
+        245, 250, 252, 78, 217, 1, 125, 208, 254, 74, 122, 141, 168, 215, 37, 40, 30, 168, 234, 6,
+        133, 205, 117, 189, 86, 86, 186, 31, 59, 216, 223, 123,
     ]);
     let arg = "inc";
     let _result: () = call_contract(hash.clone(), &arg, &Vec::new());

--- a/hello-name/call/src/lib.rs
+++ b/hello-name/call/src/lib.rs
@@ -8,16 +8,16 @@ use alloc::vec::Vec;
 
 extern crate common;
 use common::bytesrepr::ToBytes;
-use common::contract_api::{call_contract, new_uref};
 use common::contract_api::pointers::ContractPointer;
+use common::contract_api::{call_contract, new_uref};
 use common::value::Value;
 
 #[no_mangle]
 pub extern "C" fn call() {
-    //This hash comes from blake2b256( [0;32] ++ [0;8] ++ [0;4] )
+    // This hash comes from a hash of address=[48; 32]; nonce=2; fn_store_id=0
     let hash = ContractPointer::Hash([
-        164, 102, 153, 51, 236, 214, 169, 167, 126, 44, 250, 247, 179, 214, 203, 229, 239, 69, 145,
-        25, 5, 153, 113, 55, 255, 188, 176, 201, 7, 4, 42, 100,
+        141, 28, 213, 149, 230, 231, 61, 223, 143, 211, 37, 248, 146, 126, 101, 96, 197, 73, 164,
+        185, 147, 226, 1, 127, 25, 96, 126, 228, 231, 147, 193, 252,
     ]);
     let arg = "World";
     let result: String = call_contract(hash, &arg, &Vec::new());


### PR DESCRIPTION
This is as part of work on CasperLabs/CasperLabs#504. This changes the hashes which now depends on changing nonce. This also assumes specific order of testing the contracts with a standalone engine:

```sh
cargo run --bin engine-standalone \
  $WORK/contract-examples/mailing-list/define/target/wasm32-unknown-unknown/release/mailinglistdefine.wasm \
  $WORK/contract-examples/mailing-list/call/target/wasm32-unknown-unknown/release/mailinglistcall.wasm \
  $WORK/contract-examples/hello-name/define/target/wasm32-unknown-unknown/release/helloname.wasm \
  $WORK/contract-examples/hello-name/call/target/wasm32-unknown-unknown/release/helloworld.wasm \
  $WORK/contract-examples/counter/define/target/wasm32-unknown-unknown/release/counterdefine.wasm \
  $WORK/contract-examples/counter/call/target/wasm32-unknown-unknown/release/countercall.wasm
```