### PR TITLE
EE-375: Update contract-examples to use common 0.8.0 API.

### DIFF
--- a/counter/call/Cargo.toml
+++ b/counter/call/Cargo.toml
@@ -8,4 +8,4 @@ name = "countercall"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", version = "0.5.0" }
+common = { package = "casperlabs-contract-ffi", version = "0.8.0" }

--- a/counter/call/src/lib.rs
+++ b/counter/call/src/lib.rs
@@ -1,12 +1,10 @@
 #![no_std]
 #![feature(alloc)]
 
-#[macro_use]
 extern crate alloc;
 use alloc::vec::Vec;
 
 extern crate common;
-use common::bytesrepr::ToBytes;
 use common::contract_api::call_contract;
 use common::contract_api::pointers::ContractPointer;
 

--- a/counter/call/src/lib.rs
+++ b/counter/call/src/lib.rs
@@ -21,5 +21,4 @@ pub extern "C" fn call() {
         let arg = "get";
         call_contract(hash, &arg, &Vec::new())
     };
-    assert_eq!(value, 1);
 }

--- a/counter/define/Cargo.toml
+++ b/counter/define/Cargo.toml
@@ -8,4 +8,4 @@ name = "counterdefine"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", version = "0.5.0" }
+common = { package = "casperlabs-contract-ffi", version = "0.8.0" }

--- a/counter/define/src/lib.rs
+++ b/counter/define/src/lib.rs
@@ -34,5 +34,6 @@ pub extern "C" fn call() {
     let key_name = String::from("count");
     counter_urefs.insert(key_name, counter_local_key.into());
 
-    let _hash = store_function("counter_ext", counter_urefs);
+    let hash = store_function("counter_ext", counter_urefs);
+    add_uref("counter", &hash.into());
 }

--- a/hello-name/call/Cargo.toml
+++ b/hello-name/call/Cargo.toml
@@ -8,4 +8,4 @@ name = "helloworld"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", version = "0.5.0" }
+common = { package = "casperlabs-contract-ffi", version = "0.8.0" }

--- a/hello-name/call/src/lib.rs
+++ b/hello-name/call/src/lib.rs
@@ -1,13 +1,11 @@
 #![no_std]
 #![feature(alloc)]
 
-#[macro_use]
 extern crate alloc;
 use alloc::string::String;
 use alloc::vec::Vec;
 
 extern crate common;
-use common::bytesrepr::ToBytes;
 use common::contract_api::{call_contract, new_uref};
 use common::contract_api::pointers::ContractPointer;
 use common::value::Value;

--- a/hello-name/define/Cargo.toml
+++ b/hello-name/define/Cargo.toml
@@ -8,4 +8,4 @@ name = "helloname"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", version = "0.5.0" }
+common = { package = "casperlabs-contract-ffi", version = "0.8.0" }

--- a/mailing-list/call/Cargo.toml
+++ b/mailing-list/call/Cargo.toml
@@ -8,5 +8,5 @@ name = "mailinglistcall"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", version = "0.5.0" }
+common = { package = "casperlabs-contract-ffi", version = "0.8.0" }
 

--- a/mailing-list/define/Cargo.toml
+++ b/mailing-list/define/Cargo.toml
@@ -8,5 +8,5 @@ name = "mailinglistdefine"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", version = "0.5.0" }
+common = { package = "casperlabs-contract-ffi", version = "0.8.0" }
 

--- a/mailing-list/define/src/lib.rs
+++ b/mailing-list/define/src/lib.rs
@@ -11,6 +11,7 @@ extern crate common;
 use common::contract_api::*;
 use common::contract_api::pointers::UPointer;
 use common::key::Key;
+use common::uref::URef;
 
 fn get_list_key(name: &str) -> UPointer<Vec<String>> {
     get_uref(name).to_u_ptr().unwrap()
@@ -49,12 +50,13 @@ fn publish(msg: String) {
 pub extern "C" fn mailing_list_ext() {
     let method_name: String = get_arg(0);
     match method_name.as_str() {
-        "sub" => match sub(get_arg(1)).map(Key::from) {
-            Some(key) => {
-                let extra_urefs = vec![key];
-                ret(&Some(key), &extra_urefs);
+        "sub" => match sub(get_arg(1)) {
+            Some(upointer) => {
+                let extra_uref = URef::new(upointer.0, upointer.1);
+                let extra_urefs = vec![extra_uref];
+                ret(&Some(Key::from(upointer)), &extra_urefs);
             }
-            none => ret(&none, &Vec::new()),
+            _ => ret(&Option::<Key>::None, &Vec::new()),
         },
         //Note that this is totally insecure. In reality
         //the pub method would be only available under an


### PR DESCRIPTION
Blocked by: https://github.com/CasperLabs/CasperLabs/pull/650 and publishing of the new crate.