### PR TITLE
EE-390: Add test contracts for get_caller endpoint.

### DIFF
--- a/get-caller/call/Cargo.toml
+++ b/get-caller/call/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "get-caller-call"
+version = "0.1.0"
+authors = ["Mateusz Górski mateusz@casperlabs.io"]
+
+[lib]
+name = "getcallercall"
+crate-type = ["cdylib"]
+
+[dependencies]
+common = { package = "casperlabs-contract-ffi", version = "0.8.0" }
+

--- a/get-caller/call/src/lib.rs
+++ b/get-caller/call/src/lib.rs
@@ -1,0 +1,24 @@
+#![no_std]
+#![feature(alloc)]
+
+extern crate common;
+use common::contract_api::call_contract;
+use common::contract_api::pointers::ContractPointer;
+
+extern crate alloc;
+use alloc::vec::Vec;
+
+#[no_mangle]
+pub extern "C" fn call() {
+    // Assumes that `define` contract was deployed with
+    // address == 303030...
+    // nonce == 0 (this is a bug since deploy should be using NEW nonce instead of OLD)
+    // https://casperlabs.atlassian.net/browse/EE-384
+    // fn_index == 0
+    let hash = ContractPointer::Hash([
+        164, 102, 153, 51, 236, 214, 169, 167, 126, 44, 250, 247, 179, 214, 203, 229, 239, 69, 145,
+        25, 5, 153, 113, 55, 255, 188, 176, 201, 7, 4, 42, 100,
+    ]);
+    // Call `define` part of the contract.
+    call_contract(hash, &(), &Vec::new())
+}

--- a/get-caller/define/Cargo.toml
+++ b/get-caller/define/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "get-caller-define"
+version = "0.1.0"
+authors = ["Mateusz Górski mateusz@casperlabs.io"]
+
+[lib]
+name = "getcallerdefine"
+crate-type = ["cdylib"]
+
+[dependencies]
+common = { package = "casperlabs-contract-ffi", version = "0.8.0" }
+

--- a/get-caller/define/src/lib.rs
+++ b/get-caller/define/src/lib.rs
@@ -1,0 +1,27 @@
+#![no_std]
+#![feature(alloc)]
+
+extern crate alloc;
+extern crate common;
+
+use alloc::collections::btree_map::BTreeMap;
+use common::contract_api::{get_caller, store_function};
+use common::value::account::PublicKey;
+
+#[no_mangle]
+pub extern "C" fn get_caller_ext() {
+    // Assumes that will be called using account with
+    // public key == 303030...[48u8; 32] in binary representation.
+    // Will fail if we ever change that.
+    let caller = get_caller();
+    assert!(caller.is_some());
+    let expected_caller = PublicKey::new([48u8; 32]);
+    assert_eq!(caller.unwrap(), expected_caller);
+}
+
+#[no_mangle]
+pub extern "C" fn call() {
+    //  When in the base context there is no caller.
+    assert_eq!(get_caller(), None);
+    store_function("get_caller_ext", BTreeMap::new());
+}

--- a/list-known-urefs/call/Cargo.toml
+++ b/list-known-urefs/call/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "list-known-urefs-call"
+version = "0.1.0"
+authors = ["Mateusz Górski mateusz@casperlabs.io"]
+
+[lib]
+name = "listknownurefscall"
+crate-type = ["cdylib"]
+
+[dependencies]
+common = { package = "casperlabs-contract-ffi", version = "0.8.0" }
+

--- a/list-known-urefs/call/src/lib.rs
+++ b/list-known-urefs/call/src/lib.rs
@@ -1,0 +1,24 @@
+#![no_std]
+#![feature(alloc)]
+
+extern crate common;
+use common::contract_api::call_contract;
+use common::contract_api::pointers::ContractPointer;
+
+extern crate alloc;
+use alloc::vec::Vec;
+
+#[no_mangle]
+pub extern "C" fn call() {
+    // Assumes that `define` contract was deployed with
+    // address == 303030...
+    // nonce == 0 (this is a bug since deploy should be using NEW nonce instead of OLD)
+    // https://casperlabs.atlassian.net/browse/EE-384
+    // fn_index == 1
+    let hash = ContractPointer::Hash([
+        164, 102, 153, 51, 236, 214, 169, 167, 126, 44, 250, 247, 179, 214, 203, 229, 239, 69, 145,
+        25, 5, 153, 113, 55, 255, 188, 176, 201, 7, 4, 42, 100,
+    ]);
+    // Call `define` part of the contract.
+    call_contract(hash, &(), &Vec::new())
+}

--- a/list-known-urefs/define/Cargo.toml
+++ b/list-known-urefs/define/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "list-known-urefs-define"
+version = "0.1.0"
+authors = ["Mateusz Górski mateusz@casperlabs.io"]
+
+[lib]
+name = "listknownurefsdefine"
+crate-type = ["cdylib"]
+
+[dependencies]
+common = { package = "casperlabs-contract-ffi", version = "0.8.0" }
+

--- a/list-known-urefs/define/src/lib.rs
+++ b/list-known-urefs/define/src/lib.rs
@@ -1,0 +1,43 @@
+#![no_std]
+#![feature(alloc)]
+
+extern crate alloc;
+extern crate common;
+
+use alloc::borrow::ToOwned;
+use alloc::collections::btree_map::BTreeMap;
+use alloc::string::String;
+use common::contract_api::{add_uref, list_known_urefs, store_function, new_uref, get_uref};
+use common::key::Key;
+use common::value::Value;
+use core::iter;
+
+#[no_mangle]
+pub extern "C" fn list_known_urefs_ext() {
+    let passed_in_uref = get_uref("Foo");
+    let uref = new_uref(Value::String("Test".to_owned()));
+    add_uref("Bar", &uref.clone().into());
+    let contracts_known_urefs = list_known_urefs();
+    let expected_urefs: BTreeMap<String, Key> = {
+        let mut tmp = BTreeMap::new();
+        tmp.insert("Bar".to_owned(), uref.into());
+        tmp.insert("Foo".to_owned(), passed_in_uref);
+        tmp
+    };
+    // Test that `list_known_urefs` returns correct value when in the subcall (contract).
+    assert_eq!(expected_urefs, contracts_known_urefs);
+}
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let uref = new_uref(Value::Int32(1));
+    add_uref("Foo", &uref.clone().into());
+    let accounts_known_urefs = list_known_urefs();
+    let expected_urefs: BTreeMap<String, Key> =
+        iter::once(("Foo".to_owned(), uref.into())).collect();
+    // Test that `list_known_urefs` returns correct value when called in the context of an account.
+    // Store `list_known_urefs_ext` to be called in the `call` part of this contract.
+    // We don't have to  pass `expected_urefs` to exercise this function but
+    // it adds initial known urefs to the state of the contract.
+    store_function("list_known_urefs_ext", expected_urefs);
+}


### PR DESCRIPTION
Note, these can only be run using local (latest `dev`) `common` crate as that endpoint has not been published yet.