### PR TITLE
EE-430: use ContractPointer by name vs hardcoded

### DIFF
--- a/counter/call/src/lib.rs
+++ b/counter/call/src/lib.rs
@@ -5,20 +5,22 @@ extern crate alloc;
 use alloc::vec::Vec;
 
 extern crate common;
-use common::contract_api::call_contract;
+use common::contract_api::{call_contract, revert, get_uref};
 use common::contract_api::pointers::ContractPointer;
+use common::key::Key;
 
 #[no_mangle]
 pub extern "C" fn call() {
-    //This hash comes from blake2b256( [0;32] ++ [0;8] ++ [0;4] )
-    let hash = ContractPointer::Hash([
-        164, 102, 153, 51, 236, 214, 169, 167, 126, 44, 250, 247, 179, 214, 203, 229, 239, 69, 145,
-        25, 5, 153, 113, 55, 255, 188, 176, 201, 7, 4, 42, 100,
-    ]);
+    let pointer = if let Key::Hash(hash) = get_uref("counter") {
+        ContractPointer::Hash(hash)
+    } else {
+        revert(66)
+    };
+
     let arg = "inc";
-    let _result: () = call_contract(hash.clone(), &arg, &Vec::new());
+    let _result: () = call_contract(pointer.clone(), &arg, &Vec::new());
     let value: i32 = {
         let arg = "get";
-        call_contract(hash, &arg, &Vec::new())
+        call_contract(pointer, &arg, &Vec::new())
     };
 }

--- a/counter/define/src/lib.rs
+++ b/counter/define/src/lib.rs
@@ -34,6 +34,6 @@ pub extern "C" fn call() {
     let key_name = String::from("count");
     counter_urefs.insert(key_name, counter_local_key.into());
 
-    let hash = store_function("counter_ext", counter_urefs);
-    add_uref("counter", &hash.into());
+    let pointer = store_function("counter_ext", counter_urefs);
+    add_uref("counter", &pointer.into());
 }

--- a/hello-name/call/src/lib.rs
+++ b/hello-name/call/src/lib.rs
@@ -6,19 +6,20 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 extern crate common;
-use common::contract_api::{call_contract, new_uref};
 use common::contract_api::pointers::ContractPointer;
+use common::contract_api::{call_contract, get_uref, new_uref, revert};
+use common::key::Key;
 use common::value::Value;
 
 #[no_mangle]
 pub extern "C" fn call() {
-    //This hash comes from blake2b256( [0;32] ++ [0;8] ++ [0;4] )
-    let hash = ContractPointer::Hash([
-        164, 102, 153, 51, 236, 214, 169, 167, 126, 44, 250, 247, 179, 214, 203, 229, 239, 69, 145,
-        25, 5, 153, 113, 55, 255, 188, 176, 201, 7, 4, 42, 100,
-    ]);
+    let pointer = if let Key::Hash(hash) = get_uref("hello_name") {
+        ContractPointer::Hash(hash)
+    } else {
+        revert(66); // exit code is currently arbitrary
+    };
     let arg = "World";
-    let result: String = call_contract(hash, &arg, &Vec::new());
+    let result: String = call_contract(pointer, &arg, &Vec::new());
     assert_eq!("Hello, World", result);
 
     //store the result at a uref so it can be seen as an effect on the global state

--- a/hello-name/define/src/lib.rs
+++ b/hello-name/define/src/lib.rs
@@ -7,7 +7,7 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 extern crate common;
-use common::contract_api::{get_arg, ret, store_function};
+use common::contract_api::{add_uref, get_arg, ret, store_function};
 
 fn hello_name(name: &str) -> String {
     let mut result = String::from("Hello, ");
@@ -24,5 +24,6 @@ pub extern "C" fn hello_name_ext() {
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let _hash = store_function("hello_name_ext", BTreeMap::new());
+    let pointer = store_function("hello_name_ext", BTreeMap::new());
+    add_uref("hello_name", &pointer.into());
 }

--- a/mailing-list/call/src/lib.rs
+++ b/mailing-list/call/src/lib.rs
@@ -13,15 +13,16 @@ use common::key::Key;
 
 #[no_mangle]
 pub extern "C" fn call() {
-    //This hash comes from blake2b256( [0;32] ++ [0;8] ++ [0;4] )
-    let hash = ContractPointer::Hash([
-        164, 102, 153, 51, 236, 214, 169, 167, 126, 44, 250, 247, 179, 214, 203, 229, 239, 69, 145,
-        25, 5, 153, 113, 55, 255, 188, 176, 201, 7, 4, 42, 100,
-    ]);
+    let pointer = if let Key::Hash(hash) = get_uref("mailing") {
+        ContractPointer::Hash(hash)
+    } else {
+        revert(66); // exit code is currently arbitrary
+    };
+
     let method = "sub";
     let name = "CasperLabs";
     let args = (method, name);
-    let maybe_sub_key: Option<Key> = call_contract(hash.clone(), &args, &Vec::new());
+    let maybe_sub_key: Option<Key> = call_contract(pointer.clone(), &args, &Vec::new());
     let sub_key = maybe_sub_key.unwrap();
 
     let key_name = "mail_feed";
@@ -31,7 +32,7 @@ pub extern "C" fn call() {
     let method = "pub";
     let message = "Hello, World!";
     let args = (method, message);
-    let _result: () = call_contract(hash, &args, &Vec::new());
+    let _result: () = call_contract(pointer, &args, &Vec::new());
 
     let list_key: UPointer<Vec<String>> = sub_key.to_u_ptr().unwrap();
     let messages = read(list_key);

--- a/mailing-list/define/src/lib.rs
+++ b/mailing-list/define/src/lib.rs
@@ -79,5 +79,6 @@ pub extern "C" fn call() {
     let key_name = String::from("list");
     mailing_list_urefs.insert(key_name, list_key.into());
 
-    let _hash = store_function("mailing_list_ext", mailing_list_urefs);
+    let pointer = store_function("mailing_list_ext", mailing_list_urefs);
+    add_uref("mailing", &pointer.into())
 }


### PR DESCRIPTION
The PR removes hardcoded contract hashes from all of the existing contracts (call and define)

https://casperlabs.atlassian.net/browse/EE-430