### PR TITLE
OP-392: bump common version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,12 +35,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "call-hello-name"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "casperlabs-contract-ffi 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "casperlabs-contract-ffi"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -60,14 +60,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "counter-call"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "casperlabs-contract-ffi 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "counter-define"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "casperlabs-contract-ffi 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -128,14 +128,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "mailing-list-call"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "casperlabs-contract-ffi 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mailing-list-define"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "casperlabs-contract-ffi 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -231,7 +231,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "store-hello-name"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "casperlabs-contract-ffi 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -330,7 +330,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum blake2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "91721a6330935673395a0607df4d49a9cb90ae12d259f1b3e0a3f6e1d486872e"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
-"checksum casperlabs-contract-ffi 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "72ae2cab346a9669bee346de7454a14c948eab40909a0c86c4b0d066f3a8ddb5"
+"checksum casperlabs-contract-ffi 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "64127c27cb63e8b8c65741d3d74ba1f29480e7f4688fc92c84738dacf6f689d3"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 "checksum crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"

--- a/counter/call/Cargo.toml
+++ b/counter/call/Cargo.toml
@@ -8,4 +8,4 @@ name = "countercall"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", version = "0.8.0" }
+common = { package = "casperlabs-contract-ffi", version = "0.9.0" }

--- a/counter/define/Cargo.toml
+++ b/counter/define/Cargo.toml
@@ -8,4 +8,4 @@ name = "counterdefine"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", version = "0.8.0" }
+common = { package = "casperlabs-contract-ffi", version = "0.9.0" }

--- a/hello-name/call/Cargo.toml
+++ b/hello-name/call/Cargo.toml
@@ -8,4 +8,4 @@ name = "helloworld"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", version = "0.8.0" }
+common = { package = "casperlabs-contract-ffi", version = "0.9.0" }

--- a/hello-name/define/Cargo.toml
+++ b/hello-name/define/Cargo.toml
@@ -8,4 +8,4 @@ name = "helloname"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", version = "0.8.0" }
+common = { package = "casperlabs-contract-ffi", version = "0.9.0" }

--- a/mailing-list/call/Cargo.toml
+++ b/mailing-list/call/Cargo.toml
@@ -8,5 +8,5 @@ name = "mailinglistcall"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", version = "0.8.0" }
+common = { package = "casperlabs-contract-ffi", version = "0.9.0" }
 

--- a/mailing-list/define/Cargo.toml
+++ b/mailing-list/define/Cargo.toml
@@ -8,5 +8,5 @@ name = "mailinglistdefine"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", version = "0.8.0" }
+common = { package = "casperlabs-contract-ffi", version = "0.9.0" }
 


### PR DESCRIPTION
This PR updates `common` from `0.8.0` to `0.9.0`.