### PR TITLE
EE-583: Make contract-ffi a consistent alias for all crates

### DIFF
--- a/bonding/Cargo.toml
+++ b/bonding/Cargo.toml
@@ -7,5 +7,4 @@ authors = ["Michael Birch <birchmd@casperlabs.io>"]
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", version = "0.12.0" }
-
+contract-ffi = {package = "casperlabs-contract-ffi", version = "0.12.0" }

--- a/bonding/src/lib.rs
+++ b/bonding/src/lib.rs
@@ -3,12 +3,12 @@
 
 #[macro_use]
 extern crate alloc;
-extern crate common;
+extern crate contract_ffi;
 
-use common::contract_api::pointers::UPointer;
-use common::contract_api::{self, PurseTransferResult};
-use common::key::Key;
-use common::value::uint::U512;
+use contract_ffi::contract_api::pointers::UPointer;
+use contract_ffi::contract_api::{self, PurseTransferResult};
+use contract_ffi::key::Key;
+use contract_ffi::value::uint::U512;
 
 const BOND_METHOD_NAME: &str = "bond";
 const POS_CONTRACT_NAME: &str = "pos";
@@ -19,8 +19,10 @@ const POS_CONTRACT_NAME: &str = "pos";
 // Issues bonding request to the PoS contract.
 #[no_mangle]
 pub extern "C" fn call() {
-    let pos_public: UPointer<Key> =
-        unwrap_or_revert(contract_api::get_uref(POS_CONTRACT_NAME).and_then(Key::to_u_ptr), 66);
+    let pos_public: UPointer<Key> = unwrap_or_revert(
+        contract_api::get_uref(POS_CONTRACT_NAME).and_then(Key::to_u_ptr),
+        66,
+    );
     let pos_contract: Key = contract_api::read(pos_public);
     let pos_pointer = unwrap_or_revert(pos_contract.to_c_ptr(), 77);
 

--- a/counter-call/Cargo.toml
+++ b/counter-call/Cargo.toml
@@ -8,4 +8,4 @@ name = "countercall"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", version = "0.12.0" }
+contract-ffi = {package = "casperlabs-contract-ffi", version = "0.12.0" }

--- a/counter-call/src/lib.rs
+++ b/counter-call/src/lib.rs
@@ -4,10 +4,10 @@
 extern crate alloc;
 use alloc::vec::Vec;
 
-extern crate common;
-use common::contract_api::pointers::ContractPointer;
-use common::contract_api::{call_contract, get_uref, revert};
-use common::key::Key;
+extern crate contract_ffi;
+use contract_ffi::contract_api::pointers::ContractPointer;
+use contract_ffi::contract_api::{call_contract, get_uref, revert};
+use contract_ffi::key::Key;
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/counter-define/Cargo.toml
+++ b/counter-define/Cargo.toml
@@ -8,4 +8,4 @@ name = "counterdefine"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", version = "0.12.0" }
+contract-ffi = {package = "casperlabs-contract-ffi", version = "0.12.0" }

--- a/counter-define/src/lib.rs
+++ b/counter-define/src/lib.rs
@@ -6,10 +6,10 @@ use alloc::collections::BTreeMap;
 use alloc::string::String;
 use alloc::vec::Vec;
 
-extern crate common;
-use common::contract_api::pointers::UPointer;
-use common::contract_api::*;
-use common::key::Key;
+extern crate contract_ffi;
+use contract_ffi::contract_api::pointers::UPointer;
+use contract_ffi::contract_api::*;
+use contract_ffi::key::Key;
 
 #[no_mangle]
 pub extern "C" fn counter_ext() {

--- a/hello-call/Cargo.toml
+++ b/hello-call/Cargo.toml
@@ -8,4 +8,4 @@ name = "helloworld"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", version = "0.12.0" }
+contract-ffi = {package = "casperlabs-contract-ffi", version = "0.12.0" }

--- a/hello-call/src/lib.rs
+++ b/hello-call/src/lib.rs
@@ -5,11 +5,11 @@ extern crate alloc;
 use alloc::string::String;
 use alloc::vec::Vec;
 
-extern crate common;
-use common::contract_api::pointers::ContractPointer;
-use common::contract_api::{call_contract, get_uref, new_uref, revert};
-use common::key::Key;
-use common::value::Value;
+extern crate contract_ffi;
+use contract_ffi::contract_api::pointers::ContractPointer;
+use contract_ffi::contract_api::{call_contract, get_uref, new_uref, revert};
+use contract_ffi::key::Key;
+use contract_ffi::value::Value;
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/hello-define/Cargo.toml
+++ b/hello-define/Cargo.toml
@@ -8,4 +8,4 @@ name = "helloname"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", version = "0.12.0" }
+contract-ffi = {package = "casperlabs-contract-ffi", version = "0.12.0" }

--- a/hello-define/src/lib.rs
+++ b/hello-define/src/lib.rs
@@ -6,8 +6,8 @@ use alloc::collections::BTreeMap;
 use alloc::string::String;
 use alloc::vec::Vec;
 
-extern crate common;
-use common::contract_api::{add_uref, get_arg, ret, store_function};
+extern crate contract_ffi;
+use contract_ffi::contract_api::{add_uref, get_arg, ret, store_function};
 
 fn hello_name(name: &str) -> String {
     let mut result = String::from("Hello, ");

--- a/mailing-list-call/Cargo.toml
+++ b/mailing-list-call/Cargo.toml
@@ -8,5 +8,4 @@ name = "mailinglistcall"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", version = "0.12.0" }
-
+contract-ffi = {package = "casperlabs-contract-ffi", version = "0.12.0" }

--- a/mailing-list-call/src/lib.rs
+++ b/mailing-list-call/src/lib.rs
@@ -6,10 +6,10 @@ extern crate alloc;
 use alloc::string::String;
 use alloc::vec::Vec;
 
-extern crate common;
-use common::contract_api::pointers::*;
-use common::contract_api::*;
-use common::key::Key;
+extern crate contract_ffi;
+use contract_ffi::contract_api::pointers::*;
+use contract_ffi::contract_api::*;
+use contract_ffi::key::Key;
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/mailing-list-define/Cargo.toml
+++ b/mailing-list-define/Cargo.toml
@@ -8,5 +8,4 @@ name = "mailinglistdefine"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", version = "0.12.0" }
-
+contract-ffi = {package = "casperlabs-contract-ffi", version = "0.12.0" }

--- a/mailing-list-define/src/lib.rs
+++ b/mailing-list-define/src/lib.rs
@@ -7,11 +7,11 @@ use alloc::collections::BTreeMap;
 use alloc::string::String;
 use alloc::vec::Vec;
 
-extern crate common;
-use common::contract_api::pointers::UPointer;
-use common::contract_api::*;
-use common::key::Key;
-use common::uref::URef;
+extern crate contract_ffi;
+use contract_ffi::contract_api::pointers::UPointer;
+use contract_ffi::contract_api::*;
+use contract_ffi::key::Key;
+use contract_ffi::uref::URef;
 
 fn get_list_key(name: &str) -> UPointer<Vec<String>> {
     get_uref(name).and_then(Key::to_u_ptr).unwrap()

--- a/unbonding/Cargo.toml
+++ b/unbonding/Cargo.toml
@@ -7,5 +7,4 @@ authors = ["Michael Birch <birchmd@casperlabs.io>"]
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", version = "0.12.0" }
-
+contract-ffi = {package = "casperlabs-contract-ffi", version = "0.12.0" }

--- a/unbonding/src/lib.rs
+++ b/unbonding/src/lib.rs
@@ -3,12 +3,12 @@
 
 #[macro_use]
 extern crate alloc;
-extern crate common;
+extern crate contract_ffi;
 
-use common::contract_api;
-use common::contract_api::pointers::UPointer;
-use common::key::Key;
-use common::value::uint::U512;
+use contract_ffi::contract_api;
+use contract_ffi::contract_api::pointers::UPointer;
+use contract_ffi::key::Key;
+use contract_ffi::value::uint::U512;
 
 const POS_CONTRACT_NAME: &str = "pos";
 const UNBOND_METHOD_NAME: &str = "unbond";
@@ -20,8 +20,10 @@ const UNBOND_METHOD_NAME: &str = "unbond";
 // Otherwise (`Some<u64>`) unbonds with part of the bonded stakes.
 #[no_mangle]
 pub extern "C" fn call() {
-    let pos_public: UPointer<Key> =
-        unwrap_or_revert(contract_api::get_uref(POS_CONTRACT_NAME).and_then(Key::to_u_ptr), 66);
+    let pos_public: UPointer<Key> = unwrap_or_revert(
+        contract_api::get_uref(POS_CONTRACT_NAME).and_then(Key::to_u_ptr),
+        66,
+    );
     let pos_contract: Key = contract_api::read(pos_public);
     let pos_pointer = unwrap_or_revert(pos_contract.to_c_ptr(), 77);
 


### PR DESCRIPTION
This changes all `common` aliases of `casperlabs-contract-ffi` to `contract-ffi` for consistency.