### PR TITLE
EE-349: Update to match changed contract API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "autocfg"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -12,25 +12,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "blake2"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "bonding"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "casperlabs-contract-ffi 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -45,36 +45,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "casperlabs-contract-ffi"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "binascii 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "blake2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blake2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "uint 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "wee_alloc 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wee_alloc 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "counter-call"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "casperlabs-contract-ffi 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "counter-define"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "casperlabs-contract-ffi 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -87,16 +87,16 @@ name = "crypto-mac"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "digest"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -113,50 +113,50 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "generic-array"
-version = "0.12.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "hello-call"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "casperlabs-contract-ffi 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "hello-define"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "casperlabs-contract-ffi 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.58"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "mailing-list-call"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "casperlabs-contract-ffi 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mailing-list-define"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "casperlabs-contract-ffi 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -170,8 +170,8 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -179,12 +179,12 @@ name = "num-traits"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "opaque-debug"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "0.6.12"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -215,11 +215,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.15.36"
+version = "0.15.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -229,14 +229,14 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.10.0"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -253,7 +253,7 @@ dependencies = [
 name = "unbonding"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "casperlabs-contract-ffi 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -262,33 +262,19 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "unreachable"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "wee_alloc"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "memory_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "winapi"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -306,37 +292,35 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0e49efa51329a5fd37e7c79db4621af617cd4e3e5bc224939808d076077077bf"
+"checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
 "checksum binascii 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3dc96c09fe0e8441b8e0e8afa1a64f11a1994f3f146008175eccdfe67f7c0330"
-"checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
-"checksum blake2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "91721a6330935673395a0607df4d49a9cb90ae12d259f1b3e0a3f6e1d486872e"
+"checksum bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8a606a02debe2813760609f57a64a2ffd27d9fdf5b2f133eaca0b248dd92cdd2"
+"checksum blake2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "94cb07b0da6a73955f8fb85d24c466778e70cda767a568229b104f0264089330"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
-"checksum casperlabs-contract-ffi 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "03050dad8b1c536afe5213a4a4c89ca236ede8b91949878c64a0842bf25b961a"
-"checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
+"checksum casperlabs-contract-ffi 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e35d4db4598a9aad7c7e1998f7fb2c9ad56f23a18fd94607a6c322f901173af"
+"checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 "checksum crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
-"checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
+"checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
-"checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
-"checksum libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "6281b86796ba5e4366000be6e9e18bf35580adf9e63fbe2294aadb587613a319"
+"checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+"checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
 "checksum memory_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 "checksum num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "eafd0b45c5537c3ba526f79d3e75120036502bebacbb3f3220914067ce39dbf2"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
-"checksum opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "93f5bb2e8e8dec81642920ccff6b61f1eb94fa3020c5a325c9851ff604152409"
+"checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-"checksum quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "faf4799c5d274f3868a4aae320a0a182cbd2baee377b378f080e16a23e9d80db"
+"checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "403bb3a286107a04825a5f82e1270acc1e14028d3d554d7a1e08914549575ab8"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
-"checksum syn 0.15.36 (registry+https://github.com/rust-lang/crates.io-index)" = "8b4f551a91e2e3848aeef8751d0d4eec9489b6474c720fd4c55958d8d31a430c"
+"checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
-"checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
+"checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
 "checksum uint 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2143cded94692b156c356508d92888acc824db5bffc0b4089732264c6fcf86d4"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-"checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
-"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-"checksum wee_alloc 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "31d4e6572d21ac55398bc91db827f48c3fdb8152ae60f4c358f6780e1035ffcc"
-"checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"
+"checksum wee_alloc 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "dbb3b5a6b2bb17cb6ad44a2e68a43e8d2722c997da10e928665c72ec6c0a0b8e"
+"checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/bonding/Cargo.toml
+++ b/bonding/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-contract-ffi = {package = "casperlabs-contract-ffi", version = "0.15.0" }
+contract-ffi = { package = "casperlabs-contract-ffi", version = "0.16.0" }

--- a/bonding/src/lib.rs
+++ b/bonding/src/lib.rs
@@ -29,7 +29,11 @@ pub extern "C" fn call() {
 
     let source_purse = contract_api::main_purse();
     let bonding_purse = contract_api::create_purse();
-    let bond_amount: U512 = U512::from(contract_api::get_arg::<u64>(0));
+    let bond_amount: U512 = match contract_api::get_arg::<u64>(0) {
+        Some(Ok(amount)) => amount.into(),
+        Some(Err(_)) => contract_api::revert(Error::InvalidArgument.into()),
+        None => contract_api::revert(Error::MissingArgument.into()),
+    };
 
     match contract_api::transfer_from_purse_to_purse(source_purse, bonding_purse, bond_amount) {
         PurseTransferResult::TransferSuccessful => contract_api::call_contract(

--- a/bonding/src/lib.rs
+++ b/bonding/src/lib.rs
@@ -5,7 +5,7 @@ extern crate alloc;
 extern crate contract_ffi;
 
 use contract_ffi::contract_api::pointers::TURef;
-use contract_ffi::contract_api::{self, PurseTransferResult};
+use contract_ffi::contract_api::{self, Error, PurseTransferResult};
 use contract_ffi::key::Key;
 use contract_ffi::value::uint::U512;
 
@@ -22,7 +22,9 @@ pub extern "C" fn call() {
         contract_api::get_uref(POS_CONTRACT_NAME).and_then(Key::to_turef),
         66,
     );
-    let pos_contract: Key = contract_api::read(pos_public);
+    let pos_contract: Key = contract_api::read(pos_public)
+        .unwrap_or_else(|_| contract_api::revert(Error::GetURef.into()))
+        .unwrap_or_else(|| contract_api::revert(Error::ValueNotFound.into()));
     let pos_pointer = unwrap_or_revert(pos_contract.to_c_ptr(), 77);
 
     let source_purse = contract_api::main_purse();

--- a/bonding/src/lib.rs
+++ b/bonding/src/lib.rs
@@ -22,9 +22,11 @@ pub extern "C" fn call() {
         contract_api::get_uref(POS_CONTRACT_NAME).and_then(Key::to_turef),
         66,
     );
-    let pos_contract: Key = contract_api::read(pos_public)
-        .unwrap_or_else(|_| contract_api::revert(Error::GetURef.into()))
-        .unwrap_or_else(|| contract_api::revert(Error::ValueNotFound.into()));
+    let pos_contract: Key = match contract_api::read(pos_public) {
+        Ok(Some(contract)) => contract,
+        Ok(None) => contract_api::revert(Error::ValueNotFound.into()),
+        Err(_) => contract_api::revert(Error::GetURef.into())
+    };
     let pos_pointer = unwrap_or_revert(pos_contract.to_c_ptr(), 77);
 
     let source_purse = contract_api::main_purse();

--- a/counter-call/Cargo.toml
+++ b/counter-call/Cargo.toml
@@ -9,4 +9,4 @@ name = "countercall"
 crate-type = ["cdylib"]
 
 [dependencies]
-contract-ffi = {package = "casperlabs-contract-ffi", version = "0.15.0" }
+contract-ffi = { package = "casperlabs-contract-ffi", version = "0.16.0" }

--- a/counter-define/Cargo.toml
+++ b/counter-define/Cargo.toml
@@ -9,4 +9,4 @@ name = "counterdefine"
 crate-type = ["cdylib"]
 
 [dependencies]
-contract-ffi = {package = "casperlabs-contract-ffi", version = "0.15.0" }
+contract-ffi = { package = "casperlabs-contract-ffi", version = "0.16.0" }

--- a/counter-define/src/lib.rs
+++ b/counter-define/src/lib.rs
@@ -17,7 +17,9 @@ pub extern "C" fn counter_ext() {
     match method_name.as_str() {
         "inc" => add(i_key, 1),
         "get" => {
-            let result = read(i_key);
+            let result = read(i_key)
+                .unwrap_or_else(|_| revert(Error::Read.into()))
+                .unwrap_or_else(|| revert(Error::ValueNotFound.into()));
             ret(&result, &Vec::new());
         }
         _ => panic!("Unknown method name!"),

--- a/counter-define/src/lib.rs
+++ b/counter-define/src/lib.rs
@@ -13,7 +13,11 @@ use contract_ffi::key::Key;
 #[no_mangle]
 pub extern "C" fn counter_ext() {
     let i_key: TURef<i32> = get_uref("count").and_then(Key::to_turef).unwrap();
-    let method_name: String = get_arg(0);
+    let method_name: String = match get_arg(0) {
+        Some(Ok(name)) => name,
+        Some(Err(_)) => revert(Error::InvalidArgument.into()),
+        None => revert(Error::MissingArgument.into()),
+    };
     match method_name.as_str() {
         "inc" => add(i_key, 1),
         "get" => {

--- a/counter-define/src/lib.rs
+++ b/counter-define/src/lib.rs
@@ -21,9 +21,11 @@ pub extern "C" fn counter_ext() {
     match method_name.as_str() {
         "inc" => add(i_key, 1),
         "get" => {
-            let result = read(i_key)
-                .unwrap_or_else(|_| revert(Error::Read.into()))
-                .unwrap_or_else(|| revert(Error::ValueNotFound.into()));
+            let result = match read(i_key) {
+                Ok(Some(value)) => value,
+                Ok(None) => revert(Error::ValueNotFound.into()),
+                Err(_) => revert(Error::GetURef.into())
+            };
             ret(&result, &Vec::new());
         }
         _ => panic!("Unknown method name!"),

--- a/hello-call/Cargo.toml
+++ b/hello-call/Cargo.toml
@@ -9,4 +9,4 @@ name = "helloworld"
 crate-type = ["cdylib"]
 
 [dependencies]
-contract-ffi = {package = "casperlabs-contract-ffi", version = "0.15.0" }
+contract-ffi = { package = "casperlabs-contract-ffi", version = "0.16.0" }

--- a/hello-define/Cargo.toml
+++ b/hello-define/Cargo.toml
@@ -9,4 +9,4 @@ name = "helloname"
 crate-type = ["cdylib"]
 
 [dependencies]
-contract-ffi = {package = "casperlabs-contract-ffi", version = "0.15.0" }
+contract-ffi = { package = "casperlabs-contract-ffi", version = "0.16.0" }

--- a/hello-define/src/lib.rs
+++ b/hello-define/src/lib.rs
@@ -6,7 +6,7 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 extern crate contract_ffi;
-use contract_ffi::contract_api::{add_uref, get_arg, ret, store_function};
+use contract_ffi::contract_api::{add_uref, get_arg, ret, revert, store_function, Error};
 
 fn hello_name(name: &str) -> String {
     let mut result = String::from("Hello, ");
@@ -16,7 +16,11 @@ fn hello_name(name: &str) -> String {
 
 #[no_mangle]
 pub extern "C" fn hello_name_ext() {
-    let name: String = get_arg(0);
+    let name: String = match get_arg(0) {
+        Some(Ok(name)) => name,
+        Some(Err(_)) => revert(Error::InvalidArgument.into()),
+        None => revert(Error::MissingArgument.into()),
+    };
     let y = hello_name(&name);
     ret(&y, &Vec::new());
 }

--- a/mailing-list-call/Cargo.toml
+++ b/mailing-list-call/Cargo.toml
@@ -9,4 +9,4 @@ name = "mailinglistcall"
 crate-type = ["cdylib"]
 
 [dependencies]
-contract-ffi = {package = "casperlabs-contract-ffi", version = "0.15.0" }
+contract-ffi = { package = "casperlabs-contract-ffi", version = "0.16.0" }

--- a/mailing-list-call/src/lib.rs
+++ b/mailing-list-call/src/lib.rs
@@ -34,7 +34,9 @@ pub extern "C" fn call() {
     let _result: () = call_contract(pointer, &args, &Vec::new());
 
     let list_key: TURef<Vec<String>> = sub_key.to_turef().unwrap();
-    let messages = read(list_key);
+    let messages = read(list_key)
+        .unwrap_or_else(|_| revert(Error::Read.into()))
+        .unwrap_or_else(|| revert(Error::ValueNotFound.into()));
 
     assert_eq!(
         vec![String::from("Welcome!"), String::from(message)],

--- a/mailing-list-call/src/lib.rs
+++ b/mailing-list-call/src/lib.rs
@@ -34,9 +34,11 @@ pub extern "C" fn call() {
     let _result: () = call_contract(pointer, &args, &Vec::new());
 
     let list_key: TURef<Vec<String>> = sub_key.to_turef().unwrap();
-    let messages = read(list_key)
-        .unwrap_or_else(|_| revert(Error::Read.into()))
-        .unwrap_or_else(|| revert(Error::ValueNotFound.into()));
+    let messages = match read(list_key) {
+        Ok(Some(messages)) => messages,
+        Ok(None) => revert(Error::ValueNotFound.into()),
+        Err(_) => revert(Error::Read.into()),
+    };
 
     assert_eq!(
         vec![String::from("Welcome!"), String::from(message)],

--- a/mailing-list-define/Cargo.toml
+++ b/mailing-list-define/Cargo.toml
@@ -9,4 +9,4 @@ name = "mailinglistdefine"
 crate-type = ["cdylib"]
 
 [dependencies]
-contract-ffi = {package = "casperlabs-contract-ffi", version = "0.15.0" }
+contract-ffi = { package = "casperlabs-contract-ffi", version = "0.16.0" }

--- a/mailing-list-define/src/lib.rs
+++ b/mailing-list-define/src/lib.rs
@@ -18,9 +18,11 @@ fn get_list_key(name: &str) -> TURef<Vec<String>> {
 
 fn update_list(name: String) {
     let list_key = get_list_key("list");
-    let mut list = read(list_key.clone())
-        .unwrap_or_else(|_| revert(Error::GetURef.into()))
-        .unwrap_or_else(|| revert(Error::ValueNotFound.into()));
+    let mut list = match read(list_key.clone()) {
+        Ok(Some(list)) => list,
+        Ok(None) => revert(Error::ValueNotFound.into()),
+        Err(_) => revert(Error::Read.into()),
+    };
     list.push(name);
     write(list_key, list);
 }
@@ -38,14 +40,18 @@ fn sub(name: String) -> Option<TURef<Vec<String>>> {
 }
 
 fn publish(msg: String) {
-    let curr_list = read(get_list_key("list"))
-        .unwrap_or_else(|_| revert(Error::GetURef.into()))
-        .unwrap_or_else(|| revert(Error::ValueNotFound.into()));
+    let curr_list = match read(get_list_key("list")) {
+        Ok(Some(list)) => list,
+        Ok(None) => revert(Error::ValueNotFound.into()),
+        Err(_) => revert(Error::Read.into()),
+    };
     for name in curr_list.iter() {
         let uref = get_list_key(name);
-        let mut messages = read(uref.clone())
-            .unwrap_or_else(|_| revert(Error::GetURef.into()))
-            .unwrap_or_else(|| revert(Error::ValueNotFound.into()));
+        let mut messages = match read(uref.clone()) {
+            Ok(Some(messages)) => messages,
+            Ok(None) => revert(Error::ValueNotFound.into()),
+            Err(_) => revert(Error::Read.into()),
+        };
         messages.push(msg.clone());
         write(uref, messages);
     }
@@ -53,9 +59,18 @@ fn publish(msg: String) {
 
 #[no_mangle]
 pub extern "C" fn mailing_list_ext() {
-    let method_name: String = get_arg(0);
+    let method_name: String = match get_arg(0) {
+        Some(Ok(name)) => name,
+        Some(Err(_)) => revert(Error::InvalidArgument.into()),
+        None => revert(Error::MissingArgument.into()),
+    };
+    let arg1: String = match get_arg(1) {
+        Some(Ok(value)) => value,
+        Some(Err(_)) => revert(Error::InvalidArgument.into()),
+        None => revert(Error::MissingArgument.into()),
+    };
     match method_name.as_str() {
-        "sub" => match sub(get_arg(1)) {
+        "sub" => match sub(arg1) {
             Some(turef) => {
                 let extra_uref = URef::new(turef.addr(), turef.access_rights());
                 let extra_urefs = vec![extra_uref];
@@ -68,7 +83,7 @@ pub extern "C" fn mailing_list_ext() {
         //unforgable reference because otherwise anyone could
         //spam the mailing list.
         "pub" => {
-            publish(get_arg(1));
+            publish(arg1);
         }
         _ => panic!("Unknown method name!"),
     }

--- a/mailing-list-define/src/lib.rs
+++ b/mailing-list-define/src/lib.rs
@@ -18,7 +18,9 @@ fn get_list_key(name: &str) -> TURef<Vec<String>> {
 
 fn update_list(name: String) {
     let list_key = get_list_key("list");
-    let mut list = read(list_key.clone());
+    let mut list = read(list_key.clone())
+        .unwrap_or_else(|_| revert(Error::GetURef.into()))
+        .unwrap_or_else(|| revert(Error::ValueNotFound.into()));
     list.push(name);
     write(list_key, list);
 }
@@ -36,10 +38,14 @@ fn sub(name: String) -> Option<TURef<Vec<String>>> {
 }
 
 fn publish(msg: String) {
-    let curr_list = read(get_list_key("list"));
+    let curr_list = read(get_list_key("list"))
+        .unwrap_or_else(|_| revert(Error::GetURef.into()))
+        .unwrap_or_else(|| revert(Error::ValueNotFound.into()));
     for name in curr_list.iter() {
         let uref = get_list_key(name);
-        let mut messages = read(uref.clone());
+        let mut messages = read(uref.clone())
+            .unwrap_or_else(|_| revert(Error::GetURef.into()))
+            .unwrap_or_else(|| revert(Error::ValueNotFound.into()));
         messages.push(msg.clone());
         write(uref, messages);
     }

--- a/unbonding/Cargo.toml
+++ b/unbonding/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-contract-ffi = {package = "casperlabs-contract-ffi", version = "0.15.0" }
+contract-ffi = { package = "casperlabs-contract-ffi", version = "0.16.0" }

--- a/unbonding/src/lib.rs
+++ b/unbonding/src/lib.rs
@@ -4,8 +4,8 @@
 extern crate alloc;
 extern crate contract_ffi;
 
-use contract_ffi::contract_api;
 use contract_ffi::contract_api::pointers::TURef;
+use contract_ffi::contract_api::{self, Error};
 use contract_ffi::key::Key;
 use contract_ffi::value::uint::U512;
 
@@ -23,7 +23,9 @@ pub extern "C" fn call() {
         contract_api::get_uref(POS_CONTRACT_NAME).and_then(Key::to_turef),
         66,
     );
-    let pos_contract: Key = contract_api::read(pos_public);
+    let pos_contract: Key = contract_api::read(pos_public)
+        .unwrap_or_else(|_| contract_api::revert(Error::GetURef.into()))
+        .unwrap_or_else(|| contract_api::revert(Error::ValueNotFound.into()));
     let pos_pointer = unwrap_or_revert(pos_contract.to_c_ptr(), 77);
 
     let unbond_amount: Option<U512> = contract_api::get_arg::<Option<u64>>(0).map(U512::from);


### PR DESCRIPTION
This will remain a draft PR until `casperlabs-contract-ffi` v0.16.0 is published to crates.io.