### PR TITLE
EE-728: Add a big warning to the repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,14 @@
-# CasperLabs Smart Contract Examples
+# :warning: DEPRECATED :warning: CasperLabs Smart Contract Examples
+
+**This repository is no longer supported**
+
+All contract examples are currently developed in the main [CasperLabs](https://github.com/CasperLabs/CasperLabs/) repository.
+
+Existing contracts from this repository were moved to their new location in the main repo where they are actively maintained:
+
+https://github.com/CasperLabs/CasperLabs/tree/dev/execution-engine/contracts/examples
+
+---
 
 Each subdirectory contains an example of a smart contract definition and a companion contract that calls it.
 


### PR DESCRIPTION
This PR adds a big warning stating that this repository is :warning:  **DEPRECATED** :warning: .

Depends on PR CasperLabs/CasperLabs#1281 to make the new links alive, and then after merging this one we need to:

- [ ] Mark this repo as archived
- [ ] Edit description to also include `DEPRECATED` (or: obsolete/archived etc.) words
- [ ] Setting URL of this project to https://github.com/CasperLabs/CasperLabs/tree/dev/execution-engine/contracts/examples seems like good idea
- [ ] Add some topics to the repo such as `deprecated` `obsolete` and `archived`
