### PR TITLE
No ticket: fix example contract calls

### DIFF
--- a/counter-call/src/lib.rs
+++ b/counter-call/src/lib.rs
@@ -6,17 +6,13 @@ extern crate contract_ffi;
 
 use alloc::vec::Vec;
 
-use contract_ffi::contract_api::{runtime, ContractRef, Error};
-use contract_ffi::key::Key;
+use contract_ffi::contract_api::{runtime, Error};
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
 
 #[no_mangle]
 pub extern "C" fn call() {
     let contract_key = runtime::get_key("counter").unwrap_or_revert_with(Error::GetKey);
-    let pointer = match contract_key {
-        Key::Hash(hash) => ContractRef::Hash(hash),
-        _ => runtime::revert(Error::UnexpectedKeyVariant),
-    };
+    let pointer = contract_key.to_c_ptr().unwrap_or_revert_with(Error::UnexpectedKeyVariant);
 
     let arg = ("inc",);
     runtime::call_contract::<_, ()>(pointer.clone(), &arg, &Vec::new());

--- a/hello-call/src/lib.rs
+++ b/hello-call/src/lib.rs
@@ -7,22 +7,20 @@ extern crate contract_ffi;
 use alloc::string::String;
 use alloc::vec::Vec;
 
-use contract_ffi::contract_api::{runtime, storage, ContractRef, Error};
-use contract_ffi::key::Key;
+use contract_ffi::contract_api::{runtime, storage, Error};
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
 use contract_ffi::value::Value;
 
 #[no_mangle]
 pub extern "C" fn call() {
     let contract_key = runtime::get_key("hello_name").unwrap_or_revert_with(Error::GetKey);
-    let pointer = match contract_key {
-        Key::Hash(hash) => ContractRef::Hash(hash),
-        _ => runtime::revert(Error::UnexpectedKeyVariant),
-    };
+    let pointer = contract_key.to_c_ptr().unwrap_or_revert_with(Error::UnexpectedKeyVariant);
+
     let arg = ("World",);
     let result: String = runtime::call_contract(pointer, &arg, &Vec::new());
     assert_eq!("Hello, World", result);
 
     //store the result at a uref so it can be seen as an effect on the global state
-    let _uref = storage::new_turef(Value::String(result));
+    let uref = storage::new_turef(Value::String(result));
+    runtime::put_key("hello_world", &uref.into());
 }

--- a/mailing-list-call/src/lib.rs
+++ b/mailing-list-call/src/lib.rs
@@ -8,17 +8,14 @@ extern crate contract_ffi;
 use alloc::string::String;
 use alloc::vec::Vec;
 
-use contract_ffi::contract_api::{runtime, storage, ContractRef, Error, TURef};
+use contract_ffi::contract_api::{runtime, storage, Error, TURef};
 use contract_ffi::key::Key;
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
 
 #[no_mangle]
 pub extern "C" fn call() {
     let contract_key = runtime::get_key("mailing").unwrap_or_revert_with(Error::GetKey);
-    let pointer = match contract_key {
-        Key::Hash(hash) => ContractRef::Hash(hash),
-        _ => runtime::revert(Error::UnexpectedKeyVariant),
-    };
+    let pointer = contract_key.to_c_ptr().unwrap_or_revert_with(Error::UnexpectedKeyVariant);
 
     let method = "sub";
     let name = "CasperLabs";


### PR DESCRIPTION
The example contracts were broken after a recent change to `contract-ffi` where `store_function` now returns a `URef` instead of a `Hash`. This change caused the match on the key look up in the call to fail. This PR fixes this.